### PR TITLE
set defaults to something sane for our use-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2021-10-04
+
+### Changed
+
+- Changed out three default setting values
+    - `file_column_width` increased to 80 columns from 40
+    - `treat_no_relevant_lines_as_covered` set to true from false
+    - `html_filter_fully_covered` set to true from false
+
 ## 0.15.2 - 2021-10-04
 
 ### Added

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,11 @@ use Mix.Config
 
 config :chaps,
   coverage_options: [
+    treat_no_relevant_lines_as_covered: false,
+    html_filter_fully_covered: false,
     minimum_coverage: 0.0,
     template_path: "lib/templates/html/htmlcov/"
+  ],
+  terminal_options: [
+    file_column_width: 40
   ]

--- a/lib/chaps/settings.ex
+++ b/lib/chaps/settings.ex
@@ -28,7 +28,7 @@ defmodule Chaps.Settings do
       project has files with long path names.
       """,
       type: :integer,
-      default: 40
+      default: 80
     ]
   ]
 
@@ -39,7 +39,7 @@ defmodule Chaps.Settings do
       as covered (`true`) at 100% or or not covered (`false`) at 0%.
       """,
       type: :boolean,
-      default: false
+      default: true
     ],
     output_dir: [
       doc: """
@@ -77,7 +77,7 @@ defmodule Chaps.Settings do
       Wether or not to filter fully covered modules from the HTML source.
       """,
       type: :boolean,
-      default: false
+      default: true
     ]
   ]
 


### PR DESCRIPTION
changes three defaults that we use out-of-the-box everywhere

as we're (probably) currently the only users of chaps, we have the luxury of being able to make this kind of change, probably shouldn't make more changes like this if other people start using chaps since it's pretty breaking. (as a side note, it'd be good to set the lib version to `v1.0.0` soonish so we're not tempted by the 0 major version)

the three defaults being changed (that we set in every consumer)

- file_column_width: the width of the summary table shown in the terminal
    - a larger column width is necessary for projects with long file names, let's blame tony :trollface: 
- treat_no_relevant_lines_as_covered: marks modules with no significant lines of code as 100% covered instead of 0% covered
    - I don't really understand why this isn't on by default in upstream? :thinking: 
- html_filter_fully_covered: a new option not in upstream where we filter out modules from the HTML report if they're 100% covered
    - defaulting this to true makes sense in our use-case (which is the focus of this library)