### PR TITLE
filter fully covered modules from terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.0 - 2021-11-24
+
+### Added
+
+- Added a `:terminal_option` for `:filter_fully_covered`, defaulting to `true`
+    - this option filters fully covered modules from the terminal output
+
 ## 0.16.0 - 2021-10-04
 
 ### Changed

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,5 +8,6 @@ config :chaps,
     template_path: "lib/templates/html/htmlcov/"
   ],
   terminal_options: [
-    file_column_width: 40
+    file_column_width: 40,
+    filter_fully_covered: false
   ]

--- a/lib/chaps/settings.ex
+++ b/lib/chaps/settings.ex
@@ -29,6 +29,13 @@ defmodule Chaps.Settings do
       """,
       type: :integer,
       default: 80
+    ],
+    filter_fully_covered: [
+      doc: """
+      Wether to filter fully covered modules from the terminal table.
+      """,
+      type: :boolean,
+      default: true
     ]
   ]
 
@@ -187,6 +194,11 @@ defmodule Chaps.Settings do
   @doc false
   def get_print_files do
     get_terminal_options()[:print_files]
+  end
+
+  @doc false
+  def get_terminal_filter_fully_covered do
+    get_terminal_options()[:filter_fully_covered]
   end
 
   @doc false

--- a/test/chaps/html_test.exs
+++ b/test/chaps/html_test.exs
@@ -46,7 +46,8 @@ defmodule Chaps.HtmlTest do
                  get_coverage_options: fn -> coverage_options(0.0) end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Html.execute(@source_info, output_dir: @test_output_dir)
            end) =~ @stats_result
@@ -63,7 +64,8 @@ defmodule Chaps.HtmlTest do
                  get_coverage_options: fn -> coverage_options(0.0) end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Html.execute(@source_info)
            end) =~ @stats_result
@@ -78,7 +80,8 @@ defmodule Chaps.HtmlTest do
                  get_coverage_options: fn -> coverage_options(100) end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     output =
       capture_io(fn ->
         assert catch_exit(Html.execute(@source_info)) == {:shutdown, 1}
@@ -95,7 +98,8 @@ defmodule Chaps.HtmlTest do
                  get_coverage_options: fn -> coverage_options(49.9) end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Html.execute(@source_info)
            end) =~ @stats_result

--- a/test/chaps/json_test.exs
+++ b/test/chaps/json_test.exs
@@ -42,7 +42,8 @@ defmodule Chaps.JsonTest do
     get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
     get_file_col_width: fn -> 40 end,
     get_print_summary: fn -> true end,
-    get_print_files: fn -> true end do
+    get_print_files: fn -> true end,
+    get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Json.execute(@source_info)
            end) =~ @stats_result

--- a/test/chaps/lcov_test.exs
+++ b/test/chaps/lcov_test.exs
@@ -42,7 +42,8 @@ defmodule Chaps.LcovTest do
     get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
     get_file_col_width: fn -> 40 end,
     get_print_summary: fn -> true end,
-    get_print_files: fn -> true end do
+    get_print_files: fn -> true end,
+    get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Lcov.execute(@source_info)
            end) =~ @stats_result

--- a/test/chaps/local_test.exs
+++ b/test/chaps/local_test.exs
@@ -83,7 +83,8 @@ defmodule Chaps.LocalTest do
                    %{"treat_no_relevant_lines_as_covered" => true}
                  end,
                  get_file_col_width: fn -> 40 end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert String.contains?(
              Local.coverage(@empty_source_info),
              "[TOTAL] 100.0%"
@@ -95,7 +96,8 @@ defmodule Chaps.LocalTest do
                  default_coverage_value: fn -> 0.0 end,
                  get_coverage_options: fn -> [] end,
                  get_file_col_width: fn -> 40 end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert String.contains?(
              Local.coverage(@empty_source_info),
              "[TOTAL]   0.0%"
@@ -107,7 +109,8 @@ defmodule Chaps.LocalTest do
                  get_coverage_options: fn -> [minimum_coverage: 100] end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     output =
       capture_io(fn ->
         assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
@@ -124,7 +127,8 @@ defmodule Chaps.LocalTest do
                  get_coverage_options: fn -> [minimum_coverage: 49.9] end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Local.execute(@source_info)
            end) =~ @stats_result
@@ -135,7 +139,8 @@ defmodule Chaps.LocalTest do
                  get_coverage_options: fn -> [minimum_coverage: 49.9] end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> true end do
+                 get_print_files: fn -> true end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Local.execute(@source_info)
            end) =~ ""
@@ -146,7 +151,8 @@ defmodule Chaps.LocalTest do
                  get_coverage_options: fn -> [minimum_coverage: 49.9] end,
                  get_file_col_width: fn -> 40 end,
                  get_print_summary: fn -> true end,
-                 get_print_files: fn -> false end do
+                 get_print_files: fn -> false end,
+                 get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Local.execute(@source_info)
            end) =~ @stats_no_files_results

--- a/test/chaps/xml_test.exs
+++ b/test/chaps/xml_test.exs
@@ -42,7 +42,8 @@ defmodule Chaps.XmlTest do
     get_file_col_width: fn -> 40 end,
     get_print_summary: fn -> true end,
     get_print_files: fn -> true end,
-    get_xml_base_dir: fn -> "base_dir" end do
+    get_xml_base_dir: fn -> "base_dir" end,
+    get_terminal_filter_fully_covered: fn -> false end do
     assert capture_io(fn ->
              Xml.execute(@source_info)
            end) =~ @stats_result


### PR DESCRIPTION
most of the time of this feature was spent fighting the test suite :/

whatever mocking library this is feels pretty bad because you have to go add these stubs to any function that will eventually call the new function, feels bad for wrapping config

this new option hides fully covered modules from the terminal output table (and adds a disclaimer that it has done so)

the table in some large projects takes up even the most maximized of terminal screens. we can only stack so many high-res monitors vertically :P